### PR TITLE
Enable output of heex template markup from `PhoenixSlime.sigil_H/2`

### DIFF
--- a/lib/phoenix_slime.ex
+++ b/lib/phoenix_slime.ex
@@ -16,13 +16,28 @@ defmodule PhoenixSlime do
   end
 
   @doc """
-  Provides the `~L` sigil with HTML safe Slime syntax inside source files.
+  Provides the `~L` sigil for compiling Slime markup into `eex` or `heex` template code.
 
       iex> import PhoenixSlime
       iex> ~L"\""
       ...> p hello \#{"world"}
       ...> "\""
       {:safe, ["<p>hello ", "world", "</p>"]}
+
+  To use Slime within LiveComponents, where the result must be validated
+  by `Phoenix.LiveView.HTMLEngine`, the expression may be tagged with
+  the charlist `'heex'`, which will cause the Slime markup to compile
+  to a `Phoenix.LiveView.Rendered` struct.
+
+      iex> import PhoenixSlime
+      iex> assigns = %{world: "world"}
+      iex> rendered = ~L"\""
+      ...> p hello \#{@world}
+      ...> "\""heex
+      %Phoenix.LiveView.Rendered{
+        rendered |
+        static: ["<p>hello ", "</p>"]
+      }
   """
   defmacro sigil_L(expr, opts) do
     handle_sigil(expr, opts, __CALLER__.line)
@@ -34,10 +49,34 @@ defmodule PhoenixSlime do
     |> EEx.compile_string(engine: Phoenix.HTML.Engine, line: line + 1)
   end
 
+  defp handle_sigil({:<<>>, _, [expr]}, 'heex', line) do
+    expr
+     |> Slime.Renderer.precompile_heex()
+     |> EEx.compile_string(engine: Phoenix.LiveView.HTMLEngine, line: line + 1)
+  end
+
   defp handle_sigil(_, _, _) do
     raise ArgumentError,
           ~S(Templating is not allowed with #{} in ~l sigil.) <>
             ~S( Remove the #{}, use = to insert values, or ) <>
             ~S(use ~L to template with #{}.)
   end
+
+  # NOT A GREAT IDEA: conflicts with `Phoenix.LiveView.Helpers`'s own `sigil_H`
+  # KEEPING IT HERE ANYWAY: in case the `heex` charlist tag above feels kludgey in the end
+
+  # @doc ~S"""
+  # Provides .heex compatibility with the `~L` sigil with HTML safe Slime syntax for components.
+
+  # Enables using Slime to build live components
+
+  #     iex> import PhoenixSlime
+  #     iex> assigns = %{world: "world"}
+  #     iex> rendered = ~H[p hello #{@world}]
+  #     iex> rendered.static
+  #     ["<p>hello ", "</p>"]
+  # """
+  # defmacro sigil_H(expr, _opts) do
+  #   handle_sigil(expr, 'heex', __CALLER__.line)
+  # end
 end

--- a/lib/phoenix_slime.ex
+++ b/lib/phoenix_slime.ex
@@ -23,21 +23,6 @@ defmodule PhoenixSlime do
       ...> p hello \#{"world"}
       ...> "\""
       {:safe, ["<p>hello ", "world", "</p>"]}
-
-  To use Slime within LiveComponents, where the result must be validated
-  by `Phoenix.LiveView.HTMLEngine`, the expression may be tagged with
-  the charlist `'heex'`, which will cause the Slime markup to compile
-  to a `Phoenix.LiveView.Rendered` struct.
-
-      iex> import PhoenixSlime
-      iex> assigns = %{world: "world"}
-      iex> rendered = ~L"\""
-      ...> p hello \#{@world}
-      ...> "\""heex
-      %Phoenix.LiveView.Rendered{
-        rendered |
-        static: ["<p>hello ", "</p>"]
-      }
   """
   defmacro sigil_L(expr, opts) do
     handle_sigil(expr, opts, __CALLER__.line)
@@ -49,12 +34,6 @@ defmodule PhoenixSlime do
     |> EEx.compile_string(engine: Phoenix.HTML.Engine, line: line + 1)
   end
 
-  defp handle_sigil({:<<>>, _, [expr]}, 'heex', line) do
-    expr
-     |> Slime.Renderer.precompile_heex()
-     |> EEx.compile_string(engine: Phoenix.LiveView.HTMLEngine, line: line + 1)
-  end
-
   defp handle_sigil(_, _, _) do
     raise ArgumentError,
           ~S(Templating is not allowed with #{} in ~l sigil.) <>
@@ -62,21 +41,37 @@ defmodule PhoenixSlime do
             ~S(use ~L to template with #{}.)
   end
 
-  # NOT A GREAT IDEA: conflicts with `Phoenix.LiveView.Helpers`'s own `sigil_H`
-  # KEEPING IT HERE ANYWAY: in case the `heex` charlist tag above feels kludgey in the end
+  @doc ~S"""
+  Outputs the given string as a validated heex template.
 
-  # @doc ~S"""
-  # Provides .heex compatibility with the `~L` sigil with HTML safe Slime syntax for components.
+  Enables the use of Slime within components' `render/1` function.
 
-  # Enables using Slime to build live components
+      iex> import PhoenixSlime
+      iex> assigns = %{world: "world"}
+      iex> rendered = ~H[p hello #{@world}]
+      %Phoenix.LiveView.Rendered{
+        rendered |
+        static: ["<p>hello ", "</p>"]
+      }
 
-  #     iex> import PhoenixSlime
-  #     iex> assigns = %{world: "world"}
-  #     iex> rendered = ~H[p hello #{@world}]
-  #     iex> rendered.static
-  #     ["<p>hello ", "</p>"]
-  # """
-  # defmacro sigil_H(expr, _opts) do
-  #   handle_sigil(expr, 'heex', __CALLER__.line)
-  # end
+  **Note:** this sigil collides with `phoenix_live_view`'s own `sigil_H`.
+  You will likely need to change the expression within your app's `*Web.ex` file
+  where `Phoenix.LiveView.Helpers` is imported, like so:
+
+  ```diff
+  - import Phoenix.LiveView.Helpers
+  + import Phoenix.LiveView.Helpers, except: [sigil_H: 2]
+  ```
+
+  That same space is probably a fine spot to import this sigil, too, while you're at it,
+  but it's your code, you do you. I gotta go.
+  """
+  defmacro sigil_H({:<<>>, _, [expr]}, _opts) do
+    expr
+     |> Slime.Renderer.precompile_heex()
+     |> EEx.compile_string(
+          engine: Phoenix.LiveView.HTMLEngine,
+          line: __CALLER__.line + 1
+        )
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule PhoenixSlime.Mixfile do
       {:phoenix_html, "~> 3.0"},
       {:phoenix_live_view, "~> 0.17.2"},
       {:jason, "~> 1.0", optional: true},
-      {:slime, github: "tensiondriven/slime"},
+      {:slime, github: "tensiondriven/slime", branch: "master"},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -14,6 +14,6 @@
   "phoenix_view": {:hex, :phoenix_view, "1.0.0", "fea71ecaaed71178b26dd65c401607de5ec22e2e9ef141389c721b3f3d4d8011", [:mix], [{:phoenix_html, "~> 2.14.2 or ~> 3.0", [hex: :phoenix_html, repo: "hexpm", optional: true]}], "hexpm", "82be3e2516f5633220246e2e58181282c71640dab7afc04f70ad94253025db0c"},
   "plug": {:hex, :plug, "1.12.1", "645678c800601d8d9f27ad1aebba1fdb9ce5b2623ddb961a074da0b96c35187d", [:mix], [{:mime, "~> 1.0 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.3 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "d57e799a777bc20494b784966dc5fbda91eb4a09f571f76545b72a634ce0d30b"},
   "plug_crypto": {:hex, :plug_crypto, "1.2.2", "05654514ac717ff3a1843204b424477d9e60c143406aa94daf2274fdd280794d", [:mix], [], "hexpm", "87631c7ad914a5a445f0a3809f99b079113ae4ed4b867348dd9eec288cecb6db"},
-  "slime": {:git, "https://github.com/tensiondriven/slime.git", "60047c0443efbb80906455a6d7f86dcdd6dada74", []},
+  "slime": {:git, "https://github.com/tensiondriven/slime.git", "08576cecc344a05293f69912d8b2bdd3a054e3f9", [branch: "master"]},
   "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
 }


### PR DESCRIPTION
This PR adds a `PhoenixSlime.sigil_H/2`, which users
can import in place of `Phoenix.LiveView.Helpers.sigil_H/2`
to enable using Slime as the basis of the template within
their components' `render/1` function. As described in
the included documentation, Slime's sigil can be imported
in place of LiveView's sigil like so:

```diff
- import Phoenix.LiveView.Helpers
+ import Phoenix.LiveView.Helpers, except: [sigil_H: 2]
+ import PhoenixSlime, only: [sigil_H: 2]
```

Originally, this PR was written to allow `sigil_L/2` to receive
the options charlist `'heex'` in order to avoid a global namespace
collision with LiveView's own `sigil_H`, but trying to use 
PhoenixSlime's `sigil_L` in my own project made it apparent that
the deleted line in the above diff was already causing a namespace
collision, so using the `'heex'` charlist to avoid such a collision 
wasn't really worth the added complexity.

---

This PR also includes a bugfix commit:

```
Fix dependency options to specify `master` git branch

A newer version of Mix has begun to fail when running `deps.get`
while a suitable version of Slime is not already in the `/deps`
directory. This patch presumes that the head of the default
branch (in this case, presumed to be `master`) of the current
fork contains the required target version of Slime for the project.
```